### PR TITLE
[DOCS] Updates typo in prerequisites section

### DIFF
--- a/docs/guides/validation/validation_actions/how_to_trigger_email_as_a_validation_action.md
+++ b/docs/guides/validation/validation_actions/how_to_trigger_email_as_a_validation_action.md
@@ -11,7 +11,7 @@ This how-to guide assumes that you have already:
 
 * Configured an email account on the SMTP server you are going to use to send the email
 * Identified the email addresses that messages will be sent to.
-* Created a <TechnicalTag tag="checkpoint" text="Checlpoint" /> which will be configured to send the emails.
+* Created a <TechnicalTag tag="checkpoint" text="Checkpoint" /> which will be configured to send the emails.
 :::
 
 ## Steps


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes a minor typo in the page describing [How to trigger Email as an Action](https://docs.greatexpectations.io/docs/guides/validation/validation_actions/how_to_trigger_email_as_a_validation_action):
In the Prerequisites section, the word `Checkpoint` is misspelt as `Checlpoint`

### Definition of Done

- [x] My code follows the Great Expectations [style guide](https://docs.greatexpectations.io/docs/contributing/style_guides/code_style)
- [x] I have performed a [self-review](https://docs.greatexpectations.io/docs/contributing/contributing_checklist) of my own code
